### PR TITLE
Update to Ubuntu 22 and add libssl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y \
     gcc-aarch64-linux-gnu \
     gcc-arm-none-eabi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN apt-get update && apt-get install -y \
     bc \
     device-tree-compiler \
     bison \
-    flex
+    flex \
+    libssl-dev \


### PR DESCRIPTION
The upcoming kernel update should probably be updated to a more modern toolchain